### PR TITLE
Improve tag substitution script

### DIFF
--- a/Methods/change_tags_on_mx_tube.rb
+++ b/Methods/change_tags_on_mx_tube.rb
@@ -1,84 +1,75 @@
-def change_tags_on_mx(tags,tag_group,mx_tube,mode,rt_ticket,login)
-  version = "change_tag_on_mx_tube_std_order.rb version 2.1"
-  puts "Supply: tags (in correct order i.e [1,2,4,8,3,5,6,7], tag_group (id), mx_tube (id), mode ('test'/'run')\n"
-  puts "Running in test mode\n" unless mode == "run"
-  
-  ActiveRecord::Base.transaction do
-    def set_false_tags(lib_aliquots, false_tag_hash)
-      lib_tags = []
-      c = false_tag_hash.size
-      false_tag_hash.each do |library,tag|
-        aliquots = Aliquot.find_all_by_library_id(library)
-        aliquots.each do |aliquot|
-          if aliquot.receptacle.class == QcTube 
-            puts "Ignoring QcTube"
-          elsif aliquot.tag_id != -1
-            lib_tags.push(aliquot.tag)
-            aliquot.tag_id = tag
-            aliquot.save!
-            lib_aliquots << aliquot
-            puts "#{c} >> #{aliquot.receptacle.class.name} aliquot: #{aliquot.id} => Sample: #{aliquot.sample.name} => old tag: #{lib_tags.last.map_id} => new tag: #{aliquot.tag_id})"
-          end
+module ChangeTags
+
+  VERSION = "change_tag_on_mx_tube_std_order.rb version 2.2"
+  EXCLUDED_CLASSES = [QcTube]
+
+  def self.set_false_tags(lib_ids)
+    puts "Clearing library id on: #{lib_ids}"
+    Aliquot.where(library_id:lib_ids).joins(:receptacle).where('assets.sti_type NOT IN (?)',EXCLUDED_CLASSES.map(&:name)).update_all(tag_id: nil)
+  end
+
+  def self.change_tags(mx,lib_aliquots,sample_tag_hash,tag_group,rt_ticket,user,version)
+    tag_map = Hash[tag_group.tags.map {|tag| [tag.map_id,tag.id] }]
+    i = 0
+    lib_aliquots.find_each do |aliquot|
+      aliquot.tag_id = tag_map[sample_tag_hash[aliquot.sample.name]]
+      aliquot.save!
+      aliquot.reload
+      puts "#{i} >> #{aliquot.receptacle.class.name} aliquot: #{aliquot.id} => Sample: #{aliquot.sample.name} => new tag: #{aliquot.tag.map_id} - #{aliquot.tag_id}"
+      i +=1
+    end
+  end
+
+  def self.change_tags_on_mx(tags,tag_group,mx_tube,mode,rt_ticket,login)
+    version = VERSION
+    puts "Supply: tags (in correct order i.e [1,2,4,8,3,5,6,7], tag_group (id), mx_tube (id), mode ('test'/'run')\n"
+    puts "Running in test mode\n" unless mode == "run"
+    ActiveRecord::Base.uncached do
+      ActiveRecord::Base.transaction do
+
+        user = User.find_by_login login
+        mx = Asset.where(id:mx_tube).includes(aliquots: :sample).first!
+
+
+        # find the library id's of the mx_tube
+        lib_ids = mx.aliquots.map(&:library_id)
+        samples = mx.aliquots.map(&:sample).flatten.map(&:name).uniq
+        lib_aliquots = Aliquot.where(library_id:lib_ids).joins(:receptacle).where('assets.sti_type NOT IN (?)',EXCLUDED_CLASSES.map(&:name)).select('aliquots.*').preload(:sample,:receptacle,:library)
+
+
+        sample_tag_hash = Hash[samples.zip(tags)]
+        keys = sample_tag_hash.keys; nil
+        problems = samples - keys
+        if problems.empty?
+          puts "Hash and mx.aliquots match. Proceeding..."
+        else
+          puts "Problems...\n#{problems.inspect}\n"
+          raise "hash keys and mx samples do not match"
         end
-        c -=1
+
+        # Add comments before we clear the original tags
+        puts "Adding comments..."
+        comment_on = lambda { |x,text| x.comments.create!(:description => text, :user_id => user.id, :title => "Tag change #{rt_ticket}") }
+        Asset.where(id:lib_ids).includes(aliquots:{tag: :tag_group}).uniq.each do |lib|
+          comment_text = "#{user.login} changed tag from tag_group #{lib.aliquots.first.tag.tag_group.id} - tag #{lib.aliquots.first.tag.map_id} => tag_group #{tag_group} - tag #{sample_tag_hash[lib.aliquots.first.sample.name]} requested via RT ticket #{rt_ticket} using #{version}"
+          comment_on.call(lib,comment_text)
+        end
+
+        comment_text = "MX tube tags updated via RT#{rt_ticket}"
+        comment_on = lambda { |x| x.comments.create!(:description => comment_text, :user_id => user.id, :title => "Tag change #{rt_ticket}") }
+        comment_on.call(mx)
+
+        puts "sample_tag_hash: #{sample_tag_hash.inspect}\n\n"
+        puts "Setting false tags on libraries"
+        set_false_tags(lib_ids)
+
+        puts "Assigning new tags"
+        change_tags(mx,lib_aliquots,sample_tag_hash,tag_group,rt_ticket,user,version)
+
+        raise "TESTING *********" unless mode == "run"
       end
-      return lib_aliquots
     end
-  
-    def change_tags(mx,lib_aliquots,sample_tag_hash,tag_group,rt_ticket,user,version)
-      c = lib_aliquots.size
-      version = "change_tags_on_batch_with_hash v 1.1"
-      lib_aliquots.each do |aliquot|
-        aliquot.tag_id = TagGroup.find(tag_group).tags.select {|t| t.map_id == sample_tag_hash[aliquot.sample.name]}.map(&:id).first
-        aliquot.save!
-        aliquot.reload
-        puts "#{c} >> #{aliquot.receptacle.class.name} aliquot: #{aliquot.id} => Sample: #{aliquot.sample.name} => new tag: #{aliquot.tag.map_id} - #{aliquot.tag_id}"
-        c -=1
-      end
-      lib_aliquots.map(&:library).uniq.each do |lib|
-        comment_text = "#{user.login} changed tag from tag_group #{lib.aliquots.first.tag.tag_group.id} - tag #{lib.aliquots.first.tag.map_id} => tag_group #{tag_group} - tag #{sample_tag_hash[lib.aliquots.first.sample.name]} requested via RT ticket #{rt_ticket} using #{version}"
-        comment_on = lambda { |x| x.comments.create!(:description => comment_text, :user_id => user.id, :title => "Tag change #{rt_ticket}") }     
-        comment_on.call(lib)
-      end
-    
-      comment_text = "MX tube tags updated via RT#{rt_ticket}"
-      comment_on = lambda { |x| x.comments.create!(:description => comment_text, :user_id => user.id, :title => "Tag change #{rt_ticket}") }
-      comment_on.call(mx)
-    end
-  
-    user = User.find_by_login login
-    mx = Asset.find(mx_tube)
-    lib_aliquots = []
-
-    # find the library id's of the mx_tube
-    lib_ids = mx.aliquots.map(&:library_id); nil
-  
-    samples = mx.aliquots.map(&:sample).flatten.map(&:name)
-  
-    sample_tag_hash = Hash[samples.zip(tags)]
-    keys = sample_tag_hash.keys; nil
-    problems = samples - keys
-    if problems.empty?
-      puts "Hash and mx.aliquots match. Proceeding..."
-    else
-      puts "Problems...\n#{problems.inspect}\n"
-      raise "hash keys and mx samples do not match"
-    end
-  
-
-    false_tag_hash = Hash[lib_ids.zip((1..sample_tag_hash.size).entries)]
-  
-    puts "sample_tag_hash: #{sample_tag_hash.inspect}\n\n"
-    puts "false_tag_hash: #{false_tag_hash.inspect}"
-
-    puts "Setting false tags on libraries"
-    set_false_tags(lib_aliquots, false_tag_hash)
-
-    puts "Assigning new tags"
-    change_tags(mx,lib_aliquots,sample_tag_hash,tag_group,rt_ticket,user,version)
-
-    raise "TESTING *********" unless mode == "run"
   end
 end
-
-change_tags_on_mx(tags,tag_group,mx_tube,mode,rt_ticket,login)
+ActiveRecord::Base.logger.level = 3
+ChangeTags.change_tags_on_mx(tags,tag_group,mx_tube,mode,rt_ticket,login)


### PR DESCRIPTION
- Wrap in module to avoid injecting methods in global namespace
- Avoid dynamically declaring methods during method execution
- Use update_all and set tags to nil to avoid validation/boradcasting intermediate state
- Move message creation to ensure original tags are used
- I'll prepare a version 3 at some point, which we'll be able to drop directly into SS
I'll need to adject the inputs for it slightly though.